### PR TITLE
Update twitch_functions.gml: twitch_auth_app_token deferred_callback

### DIFF
--- a/source/twitch_gml/scripts/twitch_functions/twitch_functions.gml
+++ b/source/twitch_gml/scripts/twitch_functions/twitch_functions.gml
@@ -350,10 +350,10 @@ function twitch_auth_app_token(_callback_success = undefined, _callback_failed =
 	var _deferred_callback = method({ callback_success: _callback_success }, function(_data) {
 		with (__twitch_get_singleton()) {
 			twitch_app_access_token = _data.access_token
-			
-			if (is_callable(callback_success)) {
-				callback_success(_data);
-			}
+		}
+
+		if (is_callable(callback_success)) {
+			callback_success(_data);
 		}
 	});
 


### PR DESCRIPTION
Moving the callback check and call outside of the with statement. This was causing the user provided callback to never be called as it was attempting to use a non-existing function from within obj_twitch_core.